### PR TITLE
add macOS related functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
 
 before_script:
   - git --version

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
+    "php": ">=5.3.0",
     "symfony/process": "~2.3|~3.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.4.0",
     "symfony/process": "~2.3|~3.0"
   },
   "require-dev": {

--- a/src/ProcessHandler/Drivers/MacOS.php
+++ b/src/ProcessHandler/Drivers/MacOS.php
@@ -9,7 +9,7 @@ class MacOS implements DriversInterface {
     /**
      * @return \Craftpip\ProcessHandler\Process[]
      */
-    protected $options = "pid,time,vsize,user,sess,args";
+    protected $options = "pid,time,rss,user,sess,args";
 
     function getAllProcesses () {
         $process = new Process("ps -eo $this->options");

--- a/src/ProcessHandler/Drivers/MacOS.php
+++ b/src/ProcessHandler/Drivers/MacOS.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Craftpip\ProcessHandler\Drivers;
+
+use Craftpip\ProcessHandler\Process as Process2;
+use Symfony\Component\Process\Process;
+
+class MacOS implements DriversInterface {
+    /**
+     * @return \Craftpip\ProcessHandler\Process[]
+     */
+    protected $options = "pid,time,vsize,user,sess,args";
+
+    function getAllProcesses () {
+        $process = new Process("ps -eo $this->options");
+        $process->run();
+        $op = trim($process->getOutput());
+
+        return $this->parse($op);
+    }
+
+    /**
+     * @param $pid
+     *
+     * @return \Craftpip\ProcessHandler\Process[]
+     */
+    function getProcessByPid ($pid) {
+        $process = new Process("ps -p $pid -o $this->options");
+        $process->run();
+        $op = trim($process->getOutput());
+
+        return $this->parse($op);
+    }
+
+    /**
+     * @param $output
+     *
+     * @return \Craftpip\ProcessHandler\Process[]
+     */
+    private function parse ($output) {
+        $op = explode("\n", $output);
+
+
+        $processes = [];
+        foreach ($op as $k => $item) {
+            if ($k < 1)
+                continue;
+
+            $item = explode(" ", preg_replace('!\s+!', ' ', trim($item)));
+            $line = [];
+            foreach ($item as $i) {
+                if ($i != '')
+                    $line[] = $i;
+            }
+
+            $processName = implode(" ", array_slice($line, 5));
+            $processes[] = new Process2($processName, $line[0], false, $line[4], $line[2] . ' KB', 'RUNNING', $line[3], $line[1], false);
+        }
+
+        return $processes;
+    }
+}

--- a/src/ProcessHandler/Process.php
+++ b/src/ProcessHandler/Process.php
@@ -3,6 +3,7 @@
 namespace Craftpip\ProcessHandler;
 
 use Craftpip\ProcessHandler\Drivers\DriversInterface;
+use Craftpip\ProcessHandler\Drivers\MacOS;
 use Craftpip\ProcessHandler\Drivers\Unix;
 use Craftpip\ProcessHandler\Drivers\Windows;
 use Craftpip\ProcessHandler\Exception\ProcessHandlerException;

--- a/src/ProcessHandler/ProcessHandler.php
+++ b/src/ProcessHandler/ProcessHandler.php
@@ -3,6 +3,7 @@
 namespace Craftpip\ProcessHandler;
 
 use Craftpip\ProcessHandler\Drivers\DriversInterface;
+use Craftpip\ProcessHandler\Drivers\MacOS;
 use Craftpip\ProcessHandler\Drivers\Unix;
 use Craftpip\ProcessHandler\Drivers\Windows;
 use Craftpip\ProcessHandler\Exception\ProcessHandlerException;
@@ -18,6 +19,7 @@ class ProcessHandler {
      */
     public $api;
 
+    const systemMacOS = "MacOS";
     const systemWindows = "Win";
     const systemUnix = "Unix";
 
@@ -33,12 +35,18 @@ class ProcessHandler {
      */
     public function __construct ($pid = null) {
         $this->pid = $pid;
-        $this->operatingSystem = $this->isWindows() ? self::systemWindows : self::systemUnix;
+        $this->operatingSystem = $this->getCurrentOS();
 
-        if ($this->operatingSystem == self::systemWindows) {
-            $this->api = new Windows();
-        } else {
-            $this->api = new Unix();
+        switch($this->operatingSystem){
+            case self::systemMacOS:
+                $this->api = new MacOS();
+                break;
+            case self::systemWindows:
+                $this->api = new Windows();
+                break;
+            case self::systemUnix:
+                $this->api = new Unix();
+                break;
         }
 
         return $this->api;
@@ -97,8 +105,18 @@ class ProcessHandler {
         return !$process ? false : true;
     }
 
-    private function isWindows () {
-        return !(strpos(PHP_OS, 'WIN') === false);
+    /**
+     * Returns a current OS systems string using uname.
+     * You can find a list of uname strings :
+     * https://en.wikipedia.org/wiki/Uname#Table_of_standard_uname_output
+     *
+     * @return string
+     */
+    private function getCurrentOS () {
+        switch (true) {
+            case stristr(PHP_OS, 'DAR'): return self::systemMacOS;
+            case stristr(PHP_OS, 'WIN'): return self::systemWindows;
+            default : return self::systemUnix;
+        }
     }
-
 }


### PR DESCRIPTION
Hello. 
First, Sorry for my English.
I tried to use this program on macOS, but I couldn't use because have some problem.
So I added MacOS related function and sligtly changed you've made.

- Added MacOS Driver class
- Added functions that check and get current OS names include macOS
- macOS, Changed "size" options in "ps -eo" to "rss" Because macOS dosen't have "size" in ps

And I updated composer.json because some syntax that used for PHP 5.4 include.(square brackets in Drivers classe)

I Tested Ubuntu 16.04 and macOS 10.12.6 but not use phpunit.

Please check and let me know what you think.